### PR TITLE
Adicionada legenda de campos obrigatórios

### DIFF
--- a/source/includes/_nfse.md
+++ b/source/includes/_nfse.md
@@ -21,6 +21,7 @@ POST|/v2/nfse/REFERENCIA/email | Envia um email com uma cópia da nota fiscal co
 
 Cada prefeitura pode utilizar um formato diferente de XML, mas utilizando nossa API você utiliza
 um formato único de campos para todas as prefeituras. A listagem dos campos segue abaixo.
+Os campos denotados com (*) são obrigatórios.
 
 ### Geral
 


### PR DESCRIPTION
Apenas colocada legenda.

No entanto, vale revisar campos identificados como obrigatório, como:
- `natureza_operacao` - tem valor padrão (sempre?), logo não parece obrigatório
- `optante_simples_nacional` - em teste (Maceio) emite com valor padrão _falso_
- `servico` / `codigo_municipio` - em teste (Maceio) emite sem o campo (nem no nosso exemplo existe o campo, hehe)

Talvez isso faça parte de uma possível demanda de revisão (e padronização) da documentação.
Ou apenas revisar e alinhar a documentação da NFSe com a API de consulta de Municípios, que já é um excelente complemento =)