### PR TITLE
removendo beta da API de MDFe

### DIFF
--- a/source/includes/_mdfe.md
+++ b/source/includes/_mdfe.md
@@ -1,5 +1,5 @@
 
-# MDF-e (beta)
+# MDF-e
 
 A MDF-e (Manifesto Eletrônico de Documentos Fiscais) é utilizada para rastrear a circulação física da carga em transportes interestaduais, transporte de carga fracionada ou por transporte de bens que utilizam mais de uma NFe.
 


### PR DESCRIPTION
Removendo o termo "(beta)" da documentação da API de MDFe.
Solicitação feita pelo Acras 29/01/2021 por e-mail.