### PR TITLE
Correção na URL de consulta da API CFOP

### DIFF
--- a/source/includes/_cfop.md
+++ b/source/includes/_cfop.md
@@ -232,7 +232,7 @@ Utilize o método HTTP **GET**. São aceitos os seguintes parâmetros de pesquis
 Caso já saiba o código CFOP exato, e queira apenas recuperar sua descrição, utilize o link
 abaixo, substituindo CODIGO_CFOP pelo código.
 
-`https://homologacao.focusnfe.com.br/v2/cfops?CODIGO_CFOP`
+`https://homologacao.focusnfe.com.br/v2/cfops/CODIGO_CFOP`
 
 
 ## Paginação


### PR DESCRIPTION
Correção na URL de consulta da API de CFOP.

De -> `https://homologacao.focusnfe.com.br/v2/cfops?CODIGO_CFOP`
Para -> `https://homologacao.focusnfe.com.br/v2/cfops/CODIGO_CFOP`